### PR TITLE
Extend MSBuildGitHashValidate to all errors

### DIFF
--- a/build/MSBuildGitHash.targets
+++ b/build/MSBuildGitHash.targets
@@ -15,7 +15,7 @@
     </Exec>
 
     <Error 
-      Condition="'$(MSBuildGitHashExitCode)' != '0'" 
+      Condition="'$(MSBuildGitHashValidate)' == 'True' And '$(MSBuildGitHashExitCode)' != '0'" 
       Text="MSBuildGitHash error executing command $(MSBuildGitHashCommand) returned error code $(MSBuildGitHashExitCode)"
     />
 
@@ -28,7 +28,7 @@
     </Exec>
 
     <Error 
-      Condition="'$(MSBuildGitHashRemote)' != '' and '$(MSBuildGitRemoteExitCode)' != '0'" 
+      Condition="'$(MSBuildGitHashValidate)' == 'True' And '$(MSBuildGitHashRemote)' != '' and '$(MSBuildGitRemoteExitCode)' != '0'" 
       Text="MSBuildGitHash error executing command $(MSBuildGitHashRemoteCommand) returned error code $(MSBuildGitRemoteExitCode)"
     />
 


### PR DESCRIPTION
Hi Mark - I discovered your project recently and love it!  I did run into one issue with my setup, though.  I use NCrunch for continuous unit testing.  It makes shadow builds elsewhere on the filesystem.  During those builds, the git command issued MSBuildGitHash fails - I get "MSBuildGitHash error executing command git describe --long --always --dirty returned error code 128".  In the shadow folder, there's no git repo, so that's not unexpected, but it happens to break NCrunch.  Making this change allows the MSBuildGitHashValidate to suppress ALL errors not just one of them.  It fixes my issue.