### PR TITLE
Add attribute choice.

### DIFF
--- a/Package.nuspec
+++ b/Package.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>MSBuildGitHash</id>
-    <version>0.3.0</version>
+    <version>0.4.0</version>
     <authors>Mark Pflug</authors>
     <owners>Mark Pflug</owners>
     <licenseUrl>https://github.com/MarkPflug/MSBuildGitHash/blob/master/LICENSE</licenseUrl>

--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ Alternately, you can hard-code the repository URL by defining the `MSBuildGitRep
 
 Basic validation is performed on the generated hash version to ensure that a git command error doesn't result in a bad value being attached. If the validation causes problems for some reason, it can be disabled by defining the `<MSBuildGitHashValidate>False</MSBuildGitHashValidate>` in your project.
 
+Starting with version 0.4.0 you can change the default assembly attributes used to store git repo url and commit hash by using:
+```xml
+<PropertyGroup>
+...
+<MSBuildGitHashHashAssemblyAttribute>AssemblyInformationalVersion</MSBuildGitHashHashAssemblyAttribute>
+<MSBuildGitHashRepoAssemblyAttribute>AssemblyCompany</MSBuildGitHashRepoAssemblyAttribute>
+</PropertyGroup>
+```
 ## Version History
 
 _0.3.0_

--- a/build/MSBuildGitHash.targets
+++ b/build/MSBuildGitHash.targets
@@ -77,14 +77,19 @@
     </ItemGroup>
 
     <ItemGroup>
-      <AssemblyAttributes Include="AssemblyMetadata">
+      <AssemblyAttributes Include="AssemblyMetadata" Condition="'$(MSBuildGitHashHashAssemblyAttribute)' == ''">
         <_Parameter1>GitHash</_Parameter1>
         <_Parameter2>$(MSBuildGitHashValue)</_Parameter2>
       </AssemblyAttributes>
-
-      <AssemblyAttributes Include="AssemblyMetadata" Condition="'$(MSBuildGitRepository)' != ''">
+      <AssemblyAttributes Include="$(MSBuildGitHashHashAssemblyAttribute)" Condition="'$(MSBuildGitHashHashAssemblyAttribute)' != ''">
+        <_Parameter1>$(MSBuildGitHashValue)</_Parameter1>
+      </AssemblyAttributes>
+      <AssemblyAttributes Include="AssemblyMetadata" Condition="'$(MSBuildGitRepository)' != ''  And '$(MSBuildGitHashRepoAssemblyAttribute)' == ''">
         <_Parameter1>GitRepository</_Parameter1>
         <_Parameter2>$(MSBuildGitRepository)</_Parameter2>
+      </AssemblyAttributes>
+       <AssemblyAttributes Include="$(MSBuildGitHashRepoAssemblyAttribute)" Condition="'$(MSBuildGitRepository)' != ''  And '$(MSBuildGitHashRepoAssemblyAttribute)' != ''">
+        <_Parameter1>$(MSBuildGitRepository)</_Parameter1>
       </AssemblyAttributes>
     </ItemGroup>
 


### PR DESCRIPTION
## Problems:
1. `AssemblyMetadata` support has been added in .NET 4.5 . Attempt to use this package with lower version of .net framework results in compilation error.
2. `AssemblyMetadata` attributes are not displayed in FileInfo and Windows Explorer file properties. To read them it is necessary to load the assembly into app domain.

## Solution:
Add the possibility to configure which assembly attributes are used to carry information added by the package. There exist attributes available in .Net 4.0, not used in `AssemblyInfo.cs` template, displayed in Windows Explorer file properties and possible to extract without loading assemblies into appdomain. 

## Implementation
I have added this feature in a way that preserves previous version behavior by default., added example to documentation and bumped the version.