### PR TITLE
Updated to .netstandard2.0 and support for net461

### DIFF
--- a/MSBuildGitHash/MsBuildGitHash.csproj
+++ b/MSBuildGitHash/MsBuildGitHash.csproj
@@ -1,9 +1,9 @@
 ﻿<Project DefaultTargets="Pack" Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <!-- we don't compile anything, this is just to satisfy the VS project system -->
-    <TargetFrameworks>netstandard1.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <PackageId>MSBuildGitHash</PackageId>
-    <VersionPrefix>0.4.1</VersionPrefix>
+    <VersionPrefix>0.5.0</VersionPrefix>
     <PackageProjectUrl>https://github.com/MarkPflug/MSBuildGitHash</PackageProjectUrl>
     <PackageIconUrl>https://markpflug.github.io/MarkPflug.png</PackageIconUrl>
     <PackageLicenseUrl>https://github.com/MarkPflug/MSBuildGitHash/blob/master/LICENSE</PackageLicenseUrl>
@@ -19,6 +19,10 @@
     <Copyright>Copyright © Mark Pflug 2018</Copyright>
     <PackageTags>msbuild git hash version</PackageTags>
     <IncludeBuildOutput>false</IncludeBuildOutput>
+    <Version>0.5.0</Version>
+    <FileVersion>0.5.0.0</FileVersion>
+    <AssemblyVersion>0.5.0.0</AssemblyVersion>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I've updated the targets to .net standard 2.0 and .net 4.6.1 which should give pretty broad coverage to majority of active .NET projects out there.