### PR TITLE
Add MSBuildGitHashReplaceInformationalVersion option

### DIFF
--- a/MSBuildGitHash/build/MSBuildGitHash.props
+++ b/MSBuildGitHash/build/MSBuildGitHash.props
@@ -4,6 +4,6 @@
     <MSBuildGitHashValidate>True</MSBuildGitHashValidate>
     <MSBuildGitHashValidateLength>32</MSBuildGitHashValidateLength>
     <MSBuildGitHashValidateRegex>^[0-9A-Fa-f]{4,32}(-dirty|-broken)%3F%24</MSBuildGitHashValidateRegex>
-    <MSBuildGitHashReplaceInformationalVersion>True</MSBuildGitHashReplaceInformationalVersion>
+    <MSBuildGitHashReplaceInfoVersion>True</MSBuildGitHashReplaceInfoVersion>
   </PropertyGroup>
 </Project>

--- a/MSBuildGitHash/build/MSBuildGitHash.props
+++ b/MSBuildGitHash/build/MSBuildGitHash.props
@@ -4,6 +4,6 @@
     <MSBuildGitHashValidate>True</MSBuildGitHashValidate>
     <MSBuildGitHashValidateLength>32</MSBuildGitHashValidateLength>
     <MSBuildGitHashValidateRegex>^[0-9A-Fa-f]{4,32}(-dirty|-broken)%3F%24</MSBuildGitHashValidateRegex>
-    <MSBuildGitHashReplaceInfoVersion>False</MSBuildGitHashReplaceInfoVersion>
+    <MSBuildGitHashReplaceInfoVersion Condition="'$(MSBuildGitHashReplaceInfoVersion)' == ''">False</MSBuildGitHashReplaceInfoVersion>
   </PropertyGroup>
 </Project>

--- a/MSBuildGitHash/build/MSBuildGitHash.props
+++ b/MSBuildGitHash/build/MSBuildGitHash.props
@@ -4,6 +4,6 @@
     <MSBuildGitHashValidate>True</MSBuildGitHashValidate>
     <MSBuildGitHashValidateLength>32</MSBuildGitHashValidateLength>
     <MSBuildGitHashValidateRegex>^[0-9A-Fa-f]{4,32}(-dirty|-broken)%3F%24</MSBuildGitHashValidateRegex>
-    <MSBuildGitHashReplaceInfoVersion>True</MSBuildGitHashReplaceInfoVersion>
+    <MSBuildGitHashReplaceInfoVersion>False</MSBuildGitHashReplaceInfoVersion>
   </PropertyGroup>
 </Project>

--- a/MSBuildGitHash/build/MSBuildGitHash.props
+++ b/MSBuildGitHash/build/MSBuildGitHash.props
@@ -4,5 +4,6 @@
     <MSBuildGitHashValidate>True</MSBuildGitHashValidate>
     <MSBuildGitHashValidateLength>32</MSBuildGitHashValidateLength>
     <MSBuildGitHashValidateRegex>^[0-9A-Fa-f]{4,32}(-dirty|-broken)%3F%24</MSBuildGitHashValidateRegex>
+    <MSBuildGitHashReplaceInformationalVersion>True</MSBuildGitHashReplaceInformationalVersion>
   </PropertyGroup>
 </Project>

--- a/MSBuildGitHash/build/MSBuildGitHash.targets
+++ b/MSBuildGitHash/build/MSBuildGitHash.targets
@@ -59,7 +59,7 @@
   >
     <PropertyGroup>
       <MSBuildGitHashVersionAttribute>$(Version)+$(MSBuildGitHashValue)</MSBuildGitHashVersionAttribute>
-      <MSBuildGitHashVersionAttribute Condition="$(MSBuildGitHashReplaceInformationalVersion) == 'True'">$(MSBuildGitHashValue)</MSBuildGitHashVersionAttribute>
+      <MSBuildGitHashVersionAttribute Condition="$(MSBuildGitHashReplaceInfoVersion) == 'True'">$(MSBuildGitHashValue)</MSBuildGitHashVersionAttribute>
     </PropertyGroup>
 
     <ItemGroup>

--- a/MSBuildGitHash/build/MSBuildGitHash.targets
+++ b/MSBuildGitHash/build/MSBuildGitHash.targets
@@ -57,11 +57,16 @@
     Condition="'$(UsingMicrosoftNETSdk)' != 'true'"
     DependsOnTargets="GetGitHash"
   >
+    <PropertyGroup>
+      <MSBuildGitHashVersionAttribute>$(Version)+$(MSBuildGitHashValue)</MSBuildGitHashVersionAttribute>
+      <MSBuildGitHashVersionAttribute Condition="$(MSBuildGitHashReplaceInformationalVersion) == 'True'">$(MSBuildGitHashValue)</MSBuildGitHashVersionAttribute>
+    </PropertyGroup>
+
     <ItemGroup>
       <AssemblyAttributes
-        Condition="'$(Version)' != '' And '$(IncludeMSBuildGitHashInfoVersion)' == 'true'"
+        Condition="'$(MSBuildGitHashVersionAttribute)' != '' And '$(IncludeMSBuildGitHashInfoVersion)' == 'true'"
         Include="System.Reflection.AssemblyInformationalVersionAttribute">
-        <_Parameter1>$(Version)+$(MSBuildGitHashValue)</_Parameter1>
+        <_Parameter1>$(MSBuildGitHashVersionAttribute)</_Parameter1>
       </AssemblyAttributes>
     </ItemGroup>
   </Target>

--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ By default, the package will include the output of the command `git describe --l
 
 By default, the git hash is appended to the Informational Version attribute value.
 
-Alternatively, the git hash can replace the Informational Version attribute value by setting `MSBuildGitHashReplaceInformationalVersion` to `True` in your .csproj file:
+Alternatively, the git hash can replace the Informational Version attribute value by setting `MSBuildGitHashReplaceInfoVersion` to `True` in your .csproj file:
 
 ```xml
 <PropertyGroup>
-  <MSBuildGitHashReplaceInformationalVersion>True</MSBuildGitHashReplaceInformationalVersion>
+  <MSBuildGitHashReplaceInfoVersion>True</MSBuildGitHashReplaceInfoVersion>
 </PropertyGroup>
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,11 +13,25 @@ Basic validation is performed on the generated hash version to ensure that a git
 
 ## Customization
 
+### Git hash format
+
 By default, the package will include the output of the command `git describe --long --always --dirty`. This produces a truncation (first 8 hex characters) of the full repository hash. You can customize the command that is executed by defining the `MSBuildGitHashCommand` property in your .csproj file. For example, if you want to include the full hash, you can add the following:
 
 ```xml
 <PropertyGroup>
   <MSBuildGitHashCommand>git rev-parse HEAD</MSBuildGitHashCommand>
+</PropertyGroup>
+```
+
+### Informational Version (aka Product Version) format
+
+By default, the git hash is appended to the Informational Version attribute value.
+
+Alternatively, the git hash can replace the Informational Version attribute value by setting `MSBuildGitHashReplaceInformationalVersion` to `True` in your .csproj file:
+
+```xml
+<PropertyGroup>
+  <MSBuildGitHashReplaceInformationalVersion>True</MSBuildGitHashReplaceInformationalVersion>
 </PropertyGroup>
 ```
 


### PR DESCRIPTION
This PR adds the `MSBuildGitHashReplaceInformationalVersion` property.

Setting `MSBuildGitHashReplaceInformationalVersion` to `True` in your
.csproj file has the effect of replacing the Informational Version attribute value with the git hash.

```xml
<PropertyGroup>
  <MSBuildGitHashReplaceInformationalVersion>True</MSBuildGitHashReplaceInformationalVersion>
</PropertyGroup>
```