### PR TITLE
Adding ability to have as many command outputs go to meta data as needed.

### DIFF
--- a/MSBuildGitHash/build/MSBuildGitHash.props
+++ b/MSBuildGitHash/build/MSBuildGitHash.props
@@ -1,6 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <MSBuildGitHashCommand Condition="'$(MSBuildGitHashCommand)' == ''">git describe --long --always --dirty --exclude=* --abbrev=7</MSBuildGitHashCommand>
+    <MSBuildGitDescribeCommand Condition="'$(MSBuildGitDescribeCommand)' == ''">git describe --tag --abbrev=0</MSBuildGitDescribeCommand>
     <MSBuildGitHashValidate>True</MSBuildGitHashValidate>
     <MSBuildGitHashValidateLength>32</MSBuildGitHashValidateLength>
     <MSBuildGitHashValidateRegex>^[0-9A-Fa-f]{4,32}(-dirty|-broken)%3F%24</MSBuildGitHashValidateRegex>

--- a/MSBuildGitHash/build/MSBuildGitHash.props
+++ b/MSBuildGitHash/build/MSBuildGitHash.props
@@ -1,7 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <MSBuildGitHashCommand Condition="'$(MSBuildGitHashCommand)' == ''">git describe --long --always --dirty --exclude=* --abbrev=7</MSBuildGitHashCommand>
-    <MSBuildGitDescribeCommand Condition="'$(MSBuildGitDescribeCommand)' == ''">git describe --tag --abbrev=0</MSBuildGitDescribeCommand>
     <MSBuildGitHashValidate>True</MSBuildGitHashValidate>
     <MSBuildGitHashValidateLength>32</MSBuildGitHashValidateLength>
     <MSBuildGitHashValidateRegex>^[0-9A-Fa-f]{4,32}(-dirty|-broken)%3F%24</MSBuildGitHashValidateRegex>

--- a/MSBuildGitHash/build/MSBuildGitHash.targets
+++ b/MSBuildGitHash/build/MSBuildGitHash.targets
@@ -4,154 +4,139 @@
     <IncludeMSBuildGitHashMetadata Condition="'$(IncludeMSBuildGitHashMetadata)' == ''">true</IncludeMSBuildGitHashMetadata>
     <IncludeMSBuildGitHashInfoVersion Condition="'$(IncludeMSBuildGitHashInfoVersion)' == ''">true</IncludeMSBuildGitHashInfoVersion>
     <MSBuildGitHashValidateSuccess Condition="$(MSBuildGitHashValidateSuccess) == ''">$(MSBuildGitHashValidate)</MSBuildGitHashValidateSuccess>
+    <MSBuildGitRepository Condition="'$(MSBuildGitRepository)' == '' And '$(RepositoryType)' == 'git' And '$(RepositoryUrl)' != ''">$(RepositoryUrl)</MSBuildGitRepository>
   </PropertyGroup>
 
+  <!-- Existing commands to be backwards compatible -->
+  <ItemGroup>
+    <AssemblyEmbed Include="GitHash">
+      <Command>$(MSBuildGitHashCommand)</Command>
+      <ValidationRegex Condition="'$(MSBuildGitHashValidate)' == 'True'">$(MSBuildGitHashValidateRegex)</ValidationRegex>
+    </AssemblyEmbed>
+    <AssemblyEmbed Include="GitRepository">
+      <Command>$(MSBuildGitRepository)</Command>
+    </AssemblyEmbed>
+  </ItemGroup>
+
+  <!-- Execute custom commands for assembly meta data -->
   <Target
-    Name="GetGitHash"
-    BeforeTargets="WriteGitHash;GenerateAssemblyInfo">
-
-    <PropertyGroup>
-      <MSBuildGitRepository
-        Condition="'$(MSBuildGitRepository)' == '' And '$(RepositoryType)' == 'git' And '$(RepositoryUrl)' != ''"
-      >$(RepositoryUrl)</MSBuildGitRepository>
-    </PropertyGroup>
-
-    <Exec
-      Command="$(MSBuildGitHashCommand)"
-      IgnoreExitCode="true"
-      ConsoleToMsBuild="true"
+    Name="CommandBatch"
+    Inputs="@(AssemblyEmbed)"
+    Outputs="%(Identity)"
+    BeforeTargets="WriteGitHash;GenerateAssemblyInfo"
     >
-      <Output TaskParameter="ExitCode" PropertyName="MSBuildGitHashExitCode" />
-      <Output TaskParameter="ConsoleOutput" ItemName="GitVersion" />
+    <Exec
+      Condition="'%(AssemblyEmbed.Command)' != '' And '%(AssemblyEmbed.Identity)' != 'GitRepository'"
+      Command="%(AssemblyEmbed.Command)"
+      ConsoleToMsBuild="true"
+      IgnoreExitCode="true"
+      >
+      <Output PropertyName="ConsoleOutput" TaskParameter="ConsoleOutput"/>
+      <Output PropertyName="ExitCode" TaskParameter="ExitCode"/>
     </Exec>
 
-    <PropertyGroup>
-      <GitVersion>@(GitVersion)</GitVersion>
-    </PropertyGroup>
-
-    <PropertyGroup Condition="'$(MSBuildGitHashExitCode)' == '0'">
-      <MSBuildGitHashSuccess>True</MSBuildGitHashSuccess>
-    </PropertyGroup>
-
-    <PropertyGroup Condition="'$(MSBuildGitHashExitCode)' != '0'">
-      <MSBuildGitHashSuccess>False</MSBuildGitHashSuccess>
-      <!-- in the event of failure, this would contain an error message, so clear it out. -->
-      <GitVersion></GitVersion>
-      <MSBuildGitHashValidate>false</MSBuildGitHashValidate>
-    </PropertyGroup>
-
-    <Error
-      Condition="'$(MSBuildGitHashValidateSuccess)' == 'True' And '$(MSBuildGitHashSuccess)' != 'True'"
-      Text="MSBuildGitHash error executing command $(MSBuildGitHashCommand) returned error code $(MSBuildGitHashExitCode)"
-    />
-
-    <Warning
-      Condition="'$(MSBuildGitHashValidateSuccess)' != 'True' And '$(MSBuildGitHashSuccess)' != 'True'"
-      Text="MSBuildGitHash error executing command $(MSBuildGitHashCommand) returned error code $(MSBuildGitHashExitCode)"
-    />
+    <ItemGroup>
+      <AssemblyEmbed Update="%(AssemblyEmbed.Identity)">
+        <ValidationRegex Condition="'%(AssemblyEmbed.ValidationRegex)' == ''"></ValidationRegex>
+        <ConsoleOutput>$(ConsoleOutput)</ConsoleOutput>
+        <ExitCode>$(ExitCode)</ExitCode>
+      </AssemblyEmbed>
+    </ItemGroup>
 
     <PropertyGroup>
-      <MSBuildGitHashValue Condition="'$(MSBuildGitHashValue)' == ''">$(GitVersion)</MSBuildGitHashValue>
-      <MSBuildGitHashValueLength>$(MSBuildGitHashValue.Length)</MSBuildGitHashValueLength>
-      <MSBuildGitHashValueStart Condition="$(MSBuildGitHashValue.Length) &lt;= 32">$(MSBuildGitHashValue)</MSBuildGitHashValueStart>
-      <MSBuildGitHashValueStart Condition="$(MSBuildGitHashValue.Length) &gt; 32">$(MSBuildGitHashValue.Substring(0,32))</MSBuildGitHashValueStart>
-      <MSBuildGitHashRegexMatch>$([System.Text.RegularExpressions.Regex]::IsMatch($(MSBuildGitHashValue), $(MSBuildGitHashValidateRegex)))</MSBuildGitHashRegexMatch>
-      <MSBuildGitHashIsDirty>$([System.Text.RegularExpressions.Regex]::IsMatch($(MSBuildGitHashValue), $(MSBuildGitHashDirtyRegex)))</MSBuildGitHashIsDirty>
+      <MSBuildGitHashVersionAttribute>$(Version)+$(ConsoleOutput)</MSBuildGitHashVersionAttribute>
+      <MSBuildGitHashVersionAttribute Condition="'$(MSBuildGitHashReplaceInfoVersion)' == 'True'">$(ConsoleOutput)</MSBuildGitHashVersionAttribute>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(UsingMicrosoftNETSdk)' == 'true'">
+      <Filtered Condition="'%(AssemblyEmbed.Identity)' == 'GitHash'"/>
       <!-- 
-      SourceRevisionId is used by the Microsoft.NET.GenerateAssemblyInfo to populate
-      the AssemblyInformationalVersion, this only happens in SDK builds.
-      -->
-      <SourceRevisionId
-        Condition="'$(SourceRevisionId)' == '' And '$(IncludeMSBuildGitHashInfoVersion)' == 'true'"
-        >$(MSBuildGitHashValue)</SourceRevisionId>
-    </PropertyGroup>
+          SourceRevisionId is used by the Microsoft.NET.GenerateAssemblyInfo to populate
+          the AssemblyInformationalVersion, this only happens in SDK builds.
+          -->
+      <SourceRevisionId Condition="'$(SourceRevisionId)' == '' And '$(IncludeMSBuildGitHashInfoVersion)' == 'true'">
+        $(ConsoleOutput)
+      </SourceRevisionId>
 
-    <PropertyGroup Condition="'$(UsingMicrosoftNETSdk)' == 'true' And '$(MSBuildGitHashReplaceInfoVersion)' == 'True'">
       <!-- suppress the sdk handling of informational version when MSBuildGitHashReplaceInfoVersion is set -->
-      <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
-      <InformationalVersion>$(MSBuildGitHashValue)</InformationalVersion>
+      <IncludeSourceRevisionInInformationalVersion Condition="'$(MSBuildGitHashReplaceInfoVersion)' == 'True'">
+        false
+      </IncludeSourceRevisionInInformationalVersion>
+      <InformationalVersion Condition="'$(MSBuildGitHashReplaceInfoVersion)' == 'True'">
+        $(ConsoleOutput)
+      </InformationalVersion>
     </PropertyGroup>
+  </Target>
 
+  <!-- Validate outputs from target command batch -->
+  <Target
+    Name="ValidateOutput"
+    DependsOnTargets="CommandBatch"
+   >
     <Error
-      Condition="'$(MSBuildGitHashExitCode)' == '0' And '$(MSBuildGitHashValidate)' == 'True' And ($(MSBuildGitHashValueLength) &gt; $(MSBuildGitHashValidateLength) Or '$(MSBuildGitHashRegexMatch)' != 'True')"
-      Text="MSBuildGitHash hash value starting with '$(MSBuildGitHashValueStart)' was invalid."
+     Condition="'%(AssemblyEmbed.ValidationRegex)' != '' And '%(AssemblyEmbed.ExitCode)' != '0'"
+     Text="%(AssemblyEmbed.Identity) error executing command %(Command) returned error code %(ExitCode)"
     />
 
     <Warning
-      Condition="'$(MSBuildGitHashSuppressDirtyWarning)' != 'True' And '$(MSBuildGitHashIsDirty)' == 'True'"
-      Text="MSBuildGitHash: the git version is dirty. You should commit all changes before building, or the assembly versions will be inconsistent."
+      Condition="'%(AssemblyEmbed.ValidationRegex)' == '' And '%(AssemblyEmbed.ExitCode)' != '0' And '%(AssemblyEmbed.Identity)' != 'GitRepository'"
+      Text="%(AssemblyEmbed.Identity) error executing command %(AssemblyEmbed.Command) returned error code %(ExitCode)"
     />
 
-    <Exec Command="%(AssemblyEmbed.Command)"
-      IgnoreExitCode="true"
-      ConsoleToMsBuild="true"
-    >
-      <Output TaskParameter="ExitCode" PropertyName="MSBuildCustomCommandExitCode" />
-      <Output TaskParameter="ConsoleOutput" ItemName="CustomCommandOutput" />
-    </Exec>
+    <PropertyGroup>
+      <Filtered Condition="'%(AssemblyEmbed.ConsoleOutput)' != '' And '%(AssemblyEmbed.ExitCode)' == '0' And '%(AssemblyEmbed.ValidationRegex)' != ''"/>
+      <OutputValue>%(AssemblyEmbed.ConsoleOutput)</OutputValue>
+      <OutputLength>$(OutputValue.Length)</OutputLength>
+      <Regex>%(AssemblyEmbed.ValidationRegex)</Regex>
+      <OutputValueStart Condition="'%(AssemblyEmbed.Identity)' == 'GitHash' And $(OutputLength) &lt;= 32">$(OutputValue)</OutputValueStart>
+      <OutputValueStart Condition="'%(AssemblyEmbed.Identity)' == 'GitHash' And $(OutputLength) &gt; 32">$(OutputValue.Substring(0,32))</OutputValueStart>
+      <MSBuildGitHashIsDirty Condition="'%(AssemblyEmbed.Identity)' == 'GitHash'">$([System.Text.RegularExpressions.Regex]::IsMatch($(OutputValue), $(MSBuildGitHashDirtyRegex)))</MSBuildGitHashIsDirty>
+      <OutputRegexMatch>$([System.Text.RegularExpressions.Regex]::IsMatch($(OutputValue), $(Regex)))</OutputRegexMatch>
+    </PropertyGroup>
 
     <Error
-      Condition="'$(MSBuildCustomCommandExitCode)' != '0'"
-      Text="%(AssemblyEmbed.Identity) error executing command [%(AssemblyEmbed.Command)] returned error code $(MSBuildCustomCommandExitCode)"
+      Condition="'%(AssemblyEmbed.ValidationRegex)' != '' And '%(AssemblyEmbed.Identity)' == 'GitHash' And ($(OutputLength) &gt; $(OutputLength) Or '$(OutputRegexMatch)' != 'True')"
+      Text="%(AssemblyEmbed.Identity) output value starting with '$(OutputValueStart)' was invalid."
     />
 
-    <ItemGroup>
-      <CustomAttribute Include="%(AssemblyEmbed.Identity)">
-        <CustomAttributeValue>@(CustomCommandOutput)</CustomAttributeValue>
-      </CustomAttribute>
-    </ItemGroup>
+    <Warning
+      Condition="'%(AssemblyEmbed.Identity)' == 'GitHash' And '$(MSBuildGitHashSuppressDirtyWarning)' != 'True' And '$(MSBuildGitHashIsDirty)' == 'True'"
+      Text="%(AssemblyEmbed.Identity): the git version is dirty. You should commit all changes before building, or the assembly versions will be inconsistent."
+    />
+
+    <Error
+      Condition="'%(AssemblyEmbed.ValidationRegex)' != '' And '%(AssemblyEmbed.Identity)' != 'GitHash' And '$(OutputRegexMatch)' != 'True'"
+      Text="%(AssemblyEmbed.Identity) output value failed regular expression comparison [%(AssemblyEmbed.ValidationRegex)]."
+    />
 
   </Target>
 
+  <!-- Apply commands output to assembly meta data -->
   <Target
-    Name="GenerateAssemblyVersionAttributes"
-    Condition="'$(UsingMicrosoftNETSdk)' != 'True'"
-    DependsOnTargets="GetGitHash"
+    Name="GenerateAssemblyAttributes"
+    DependsOnTargets="ValidateOutput"
   >
-    <PropertyGroup>
-      <MSBuildGitHashVersionAttribute>$(Version)+$(MSBuildGitHashValue)</MSBuildGitHashVersionAttribute>
-      <MSBuildGitHashVersionAttribute Condition="'$(MSBuildGitHashReplaceInfoVersion)' == 'True'">$(MSBuildGitHashValue)</MSBuildGitHashVersionAttribute>
-    </PropertyGroup>
-
     <ItemGroup>
+      <AssemblyAttributes Include="AssemblyMetadata">
+        <_Parameter1>%(AssemblyEmbed.Identity)</_Parameter1>
+        <_Parameter2>%(AssemblyEmbed.ConsoleOutput)</_Parameter2>
+      </AssemblyAttributes>
+
       <AssemblyAttributes
         Condition="'$(MSBuildGitHashVersionAttribute)' != '' And '$(IncludeMSBuildGitHashInfoVersion)' == 'true'"
-        Include="System.Reflection.AssemblyInformationalVersionAttribute">
+        Include="System.Reflection.AssemblyInformationalVersionAttribute"
+      >
         <_Parameter1>$(MSBuildGitHashVersionAttribute)</_Parameter1>
       </AssemblyAttributes>
     </ItemGroup>
   </Target>
 
-  <Target
-    Name="GenerateAssemblyAttributes"
-    DependsOnTargets="GetGitHash"
-  >
-    <ItemGroup>
-      <!--<AssemblyAttributes Include="AssemblyMetadata" Condition="'$(IncludeMSBuildGitHashMetadata)' == 'true'">
-        <_Parameter1>GitHash</_Parameter1>
-        <_Parameter2>$(MSBuildGitHashValue)</_Parameter2>
-      </AssemblyAttributes>-->
-
-      <AssemblyAttributes Include="AssemblyMetadata" Condition="'$(MSBuildGitRepository)' != '' And '$(IncludeMSBuildGitHashMetadata)' == 'true'">
-        <_Parameter1>GitRepository</_Parameter1>
-        <_Parameter2>$(MSBuildGitRepository)</_Parameter2>
-      </AssemblyAttributes>
-
-      <AssemblyAttributes Include="AssemblyMetadata">
-        <_Parameter1>%(CustomAttribute.Identity)</_Parameter1>
-        <_Parameter2>%(CustomAttribute.CustomAttributeValue)</_Parameter2>
-      </AssemblyAttributes>
-    </ItemGroup>
-  </Target>
-
+  <!-- Write the git hash to assembly info file -->
   <Target
     Name="WriteGitHash"
-    DependsOnTargets="GenerateAssemblyAttributes;GenerateAssemblyVersionAttributes"
-    BeforeTargets="CoreCompile">
-
+    DependsOnTargets="GenerateAssemblyAttributes"
+    BeforeTargets="CoreCompile"
+  >
     <PropertyGroup>
       <LanguageExt Condition="'$(Language)' == 'C#'">.cs</LanguageExt>
       <LanguageExt Condition="'$(Language)' == 'VB'">.vb</LanguageExt>
@@ -170,7 +155,5 @@
         Include="$(MSBuildGitHashAssemblyInfoFile)"
         Condition="Exists('$(MSBuildGitHashAssemblyInfoFile)')" />
     </ItemGroup>
-
   </Target>
-
 </Project>

--- a/MSBuildGitHash/build/MSBuildGitHash.targets
+++ b/MSBuildGitHash/build/MSBuildGitHash.targets
@@ -2,7 +2,9 @@
 
   <PropertyGroup>
     <IncludeMSBuildGitHashMetadata Condition="'$(IncludeMSBuildGitHashMetadata)' == ''">true</IncludeMSBuildGitHashMetadata>
+    <IncludeMSBuildGitDescribeMetadata Condition="'$(IncludeMSBuildGitDescribeMetadata)' == ''">true</IncludeMSBuildGitDescribeMetadata>
     <IncludeMSBuildGitHashInfoVersion Condition="'$(IncludeMSBuildGitHashInfoVersion)' == ''">true</IncludeMSBuildGitHashInfoVersion>
+    <IncludeMSBuildGitDescribeAssemblyVersion Condition="'$(IncludeMSBuildGitDescribeAssemblyVersion)' == ''">false</IncludeMSBuildGitDescribeAssemblyVersion>
     <MSBuildGitHashValidateSuccess Condition="$(MSBuildGitHashValidateSuccess) == ''">$(MSBuildGitHashValidate)</MSBuildGitHashValidateSuccess>
   </PropertyGroup>
 
@@ -88,13 +90,37 @@
   </Target>
 
   <Target
+    Name="GetGitDescribe"
+    BeforeTargets="WriteGitHash;GenerateAssemblyInfo"
+  >
+    <Exec
+      Command="$(MSBuildGitDescribeCommand)"
+      IgnoreExitCode="true"
+      ConsoleToMsBuild="true"
+    >
+      <Output TaskParameter="ExitCode" PropertyName="MSBuildGitDescribeExitCode" />
+      <Output TaskParameter="ConsoleOutput" ItemName="GitDescribe" />
+    </Exec>
+
+    <PropertyGroup>
+      <GitDescribe>@(GitDescribe)</GitDescribe>
+    </PropertyGroup>
+
+    <Error
+      Condition="'$(MSBuildGitDescribeExitCode)' != '0'"
+      Text="MSBuildGitDescribe error executing command $(MSBuildGitDescribeCommand) returned error code $(MSBuildGitDescribeExitCode)"
+    />
+  </Target>
+
+  <Target
     Name="GenerateAssemblyVersionAttributes"
     Condition="'$(UsingMicrosoftNETSdk)' != 'True'"
-    DependsOnTargets="GetGitHash"
+    DependsOnTargets="GetGitHash;GetGitDescribe"
   >
     <PropertyGroup>
       <MSBuildGitHashVersionAttribute>$(Version)+$(MSBuildGitHashValue)</MSBuildGitHashVersionAttribute>
       <MSBuildGitHashVersionAttribute Condition="'$(MSBuildGitHashReplaceInfoVersion)' == 'True'">$(MSBuildGitHashValue)</MSBuildGitHashVersionAttribute>
+      <MSBuildGitDescribeAttribute Condition="'$(GitDescribe)' != ''">$(GitDescribe)</MSBuildGitDescribeAttribute>
     </PropertyGroup>
 
     <ItemGroup>
@@ -103,22 +129,30 @@
         Include="System.Reflection.AssemblyInformationalVersionAttribute">
         <_Parameter1>$(MSBuildGitHashVersionAttribute)</_Parameter1>
       </AssemblyAttributes>
+      <AssemblyAttributes
+        Condition="'$(MSBuildGitDescribeAttribute)' != '' And '$(IncludeMSBuildGitDescribeAssemblyVersion)' == 'true'"
+        Include="System.Reflection.AssemblyVersionAttribute">
+        <_Parameter1>$(MSBuildGitDescribeAttribute)</_Parameter1>
+      </AssemblyAttributes>
     </ItemGroup>
   </Target>
   
   <Target
     Name="GenerateAssemblyAttributes"
-    DependsOnTargets="GetGitHash"
+    DependsOnTargets="GetGitHash;GetGitDescribe"
   >
-    <ItemGroup
-      Condition="'$(IncludeMSBuildGitHashMetadata)' == 'true'"
-    >
-      <AssemblyAttributes Include="AssemblyMetadata">
+    <ItemGroup>
+      <AssemblyAttributes Include="AssemblyMetadata" Condition="'$(IncludeMSBuildGitHashMetadata)' == 'true'">
         <_Parameter1>GitHash</_Parameter1>
         <_Parameter2>$(MSBuildGitHashValue)</_Parameter2>
       </AssemblyAttributes>
 
-      <AssemblyAttributes Include="AssemblyMetadata" Condition="'$(MSBuildGitRepository)' != ''">
+      <AssemblyAttributes Include="AssemblyMetadata" Condition="'$(IncludeMSBuildGitDescribeMetadata)' == 'true'">
+        <_Parameter1>GitDescribe</_Parameter1>
+        <_Parameter2>$(GitDescribe)</_Parameter2>
+      </AssemblyAttributes>
+
+      <AssemblyAttributes Include="AssemblyMetadata" Condition="'$(MSBuildGitRepository)' != '' And '$(IncludeMSBuildGitHashMetadata)' == 'true'">
         <_Parameter1>GitRepository</_Parameter1>
         <_Parameter2>$(MSBuildGitRepository)</_Parameter2>
       </AssemblyAttributes>

--- a/MSBuildGitHash/build/MSBuildGitHash.targets
+++ b/MSBuildGitHash/build/MSBuildGitHash.targets
@@ -24,11 +24,11 @@
       <Output TaskParameter="ExitCode" PropertyName="MSBuildGitHashExitCode" />
       <Output TaskParameter="ConsoleOutput" ItemName="GitVersion" />
     </Exec>
-    
+
     <PropertyGroup>
       <GitVersion>@(GitVersion)</GitVersion>
     </PropertyGroup>
-    
+
     <PropertyGroup Condition="'$(MSBuildGitHashExitCode)' == '0'">
       <MSBuildGitHashSuccess>True</MSBuildGitHashSuccess>
     </PropertyGroup>
@@ -80,40 +80,36 @@
       Text="MSBuildGitHash hash value starting with '$(MSBuildGitHashValueStart)' was invalid."
     />
 
-    <Warning 
+    <Warning
       Condition="'$(MSBuildGitHashSuppressDirtyWarning)' != 'True' And '$(MSBuildGitHashIsDirty)' == 'True'"
       Text="MSBuildGitHash: the git version is dirty. You should commit all changes before building, or the assembly versions will be inconsistent."
     />
 
-  </Target>
-
-  <Target
-    Name="GetGitDescribe"
-    BeforeTargets="WriteGitHash;GenerateAssemblyInfo"
-  >
-    <Exec
-      Command="$(MSBuildGitDescribeCommand)"
+    <Exec Command="%(AssemblyEmbed.Command)"
       IgnoreExitCode="true"
       ConsoleToMsBuild="true"
     >
-      <Output TaskParameter="ExitCode" PropertyName="MSBuildGitDescribeExitCode" />
-      <Output TaskParameter="ConsoleOutput" ItemName="GitDescribe" />
+      <Output TaskParameter="ExitCode" PropertyName="MSBuildCustomCommandExitCode" />
+      <Output TaskParameter="ConsoleOutput" ItemName="CustomCommandOutput" />
     </Exec>
 
-    <PropertyGroup>
-      <GitDescribe>@(GitDescribe)</GitDescribe>
-    </PropertyGroup>
-
     <Error
-      Condition="'$(MSBuildGitDescribeExitCode)' != '0'"
-      Text="MSBuildGitDescribe error executing command $(MSBuildGitDescribeCommand) returned error code $(MSBuildGitDescribeExitCode)"
+      Condition="'$(MSBuildCustomCommandExitCode)' != '0'"
+      Text="%(AssemblyEmbed.Identity) error executing command [%(AssemblyEmbed.Command)] returned error code $(MSBuildCustomCommandExitCode)"
     />
+
+    <ItemGroup>
+      <CustomAttribute Include="%(AssemblyEmbed.Identity)">
+        <CustomAttributeValue>@(CustomCommandOutput)</CustomAttributeValue>
+      </CustomAttribute>
+    </ItemGroup>
+
   </Target>
 
   <Target
     Name="GenerateAssemblyVersionAttributes"
     Condition="'$(UsingMicrosoftNETSdk)' != 'True'"
-    DependsOnTargets="GetGitHash;GetGitDescribe"
+    DependsOnTargets="GetGitHash"
   >
     <PropertyGroup>
       <MSBuildGitHashVersionAttribute>$(Version)+$(MSBuildGitHashValue)</MSBuildGitHashVersionAttribute>
@@ -128,25 +124,25 @@
       </AssemblyAttributes>
     </ItemGroup>
   </Target>
-  
+
   <Target
     Name="GenerateAssemblyAttributes"
-    DependsOnTargets="GetGitHash;GetGitDescribe"
+    DependsOnTargets="GetGitHash"
   >
     <ItemGroup>
-      <AssemblyAttributes Include="AssemblyMetadata" Condition="'$(IncludeMSBuildGitHashMetadata)' == 'true'">
+      <!--<AssemblyAttributes Include="AssemblyMetadata" Condition="'$(IncludeMSBuildGitHashMetadata)' == 'true'">
         <_Parameter1>GitHash</_Parameter1>
         <_Parameter2>$(MSBuildGitHashValue)</_Parameter2>
-      </AssemblyAttributes>
-
-      <AssemblyAttributes Include="AssemblyMetadata">
-        <_Parameter1>GitDescribe</_Parameter1>
-        <_Parameter2>$(GitDescribe)</_Parameter2>
-      </AssemblyAttributes>
+      </AssemblyAttributes>-->
 
       <AssemblyAttributes Include="AssemblyMetadata" Condition="'$(MSBuildGitRepository)' != '' And '$(IncludeMSBuildGitHashMetadata)' == 'true'">
         <_Parameter1>GitRepository</_Parameter1>
         <_Parameter2>$(MSBuildGitRepository)</_Parameter2>
+      </AssemblyAttributes>
+
+      <AssemblyAttributes Include="AssemblyMetadata">
+        <_Parameter1>%(CustomAttribute.Identity)</_Parameter1>
+        <_Parameter2>%(CustomAttribute.CustomAttributeValue)</_Parameter2>
       </AssemblyAttributes>
     </ItemGroup>
   </Target>
@@ -164,8 +160,8 @@
       <MSBuildGitHashAssemblyInfoFile>$(IntermediateOutputPath)MSBuildGitHashAssemblyInfo$(LanguageExt)</MSBuildGitHashAssemblyInfoFile>
     </PropertyGroup>
 
-    <WriteCodeFragment 
-      Language="$(CodeGenLanguage)" 
+    <WriteCodeFragment
+      Language="$(CodeGenLanguage)"
       OutputFile="$(MSBuildGitHashAssemblyInfoFile)"
       AssemblyAttributes="@(AssemblyAttributes)" />
 
@@ -176,4 +172,5 @@
     </ItemGroup>
 
   </Target>
+
 </Project>

--- a/MSBuildGitHash/build/MSBuildGitHash.targets
+++ b/MSBuildGitHash/build/MSBuildGitHash.targets
@@ -2,9 +2,7 @@
 
   <PropertyGroup>
     <IncludeMSBuildGitHashMetadata Condition="'$(IncludeMSBuildGitHashMetadata)' == ''">true</IncludeMSBuildGitHashMetadata>
-    <IncludeMSBuildGitDescribeMetadata Condition="'$(IncludeMSBuildGitDescribeMetadata)' == ''">true</IncludeMSBuildGitDescribeMetadata>
     <IncludeMSBuildGitHashInfoVersion Condition="'$(IncludeMSBuildGitHashInfoVersion)' == ''">true</IncludeMSBuildGitHashInfoVersion>
-    <IncludeMSBuildGitDescribeAssemblyVersion Condition="'$(IncludeMSBuildGitDescribeAssemblyVersion)' == ''">false</IncludeMSBuildGitDescribeAssemblyVersion>
     <MSBuildGitHashValidateSuccess Condition="$(MSBuildGitHashValidateSuccess) == ''">$(MSBuildGitHashValidate)</MSBuildGitHashValidateSuccess>
   </PropertyGroup>
 
@@ -120,7 +118,6 @@
     <PropertyGroup>
       <MSBuildGitHashVersionAttribute>$(Version)+$(MSBuildGitHashValue)</MSBuildGitHashVersionAttribute>
       <MSBuildGitHashVersionAttribute Condition="'$(MSBuildGitHashReplaceInfoVersion)' == 'True'">$(MSBuildGitHashValue)</MSBuildGitHashVersionAttribute>
-      <MSBuildGitDescribeAttribute Condition="'$(GitDescribe)' != ''">$(GitDescribe)</MSBuildGitDescribeAttribute>
     </PropertyGroup>
 
     <ItemGroup>
@@ -128,11 +125,6 @@
         Condition="'$(MSBuildGitHashVersionAttribute)' != '' And '$(IncludeMSBuildGitHashInfoVersion)' == 'true'"
         Include="System.Reflection.AssemblyInformationalVersionAttribute">
         <_Parameter1>$(MSBuildGitHashVersionAttribute)</_Parameter1>
-      </AssemblyAttributes>
-      <AssemblyAttributes
-        Condition="'$(MSBuildGitDescribeAttribute)' != '' And '$(IncludeMSBuildGitDescribeAssemblyVersion)' == 'true'"
-        Include="System.Reflection.AssemblyVersionAttribute">
-        <_Parameter1>$(MSBuildGitDescribeAttribute)</_Parameter1>
       </AssemblyAttributes>
     </ItemGroup>
   </Target>
@@ -147,7 +139,7 @@
         <_Parameter2>$(MSBuildGitHashValue)</_Parameter2>
       </AssemblyAttributes>
 
-      <AssemblyAttributes Include="AssemblyMetadata" Condition="'$(IncludeMSBuildGitDescribeMetadata)' == 'true'">
+      <AssemblyAttributes Include="AssemblyMetadata">
         <_Parameter1>GitDescribe</_Parameter1>
         <_Parameter2>$(GitDescribe)</_Parameter2>
       </AssemblyAttributes>

--- a/README.md
+++ b/README.md
@@ -34,6 +34,24 @@ Alternatively, the git hash can replace the Informational Version attribute valu
   <MSBuildGitHashReplaceInfoVersion>True</MSBuildGitHashReplaceInfoVersion>
 </PropertyGroup>
 ```
+### Git describe format
+
+By default, the package will include the output of the command `git describe --tag --abbrev=0` which will produce the last tag name only.  You can customize the command that is executed by defining the `MSBuildGitDescribeCommand` property in your .csproj file.  For example, if you want the entire tag with the 7 hexadecimal digits representing the abbreviated object name, you can do the following:
+
+```xml
+<PropertyGroup>
+  <MSBuildGitDescribeCommand>git describe --tag</MSBuildGitDescribeCommand>
+</PropertyGroup>
+```
+### Assembly version format
+
+By default, this is not overridden. If you would like the `MSBuildGitDescribeCommand` output to override the Assembly Version, then you can do the following:
+
+```xml
+<PropertyGroup>
+  <IncludeMSBuildGitDescribeAssemblyVersion>True</IncludeMSBuildGitDescribeAssemblyVersion>
+</PropertyGroup>
+```
 
 ## Version History
 _1.0.2_

--- a/README.md
+++ b/README.md
@@ -34,14 +34,26 @@ Alternatively, the git hash can replace the Informational Version attribute valu
   <MSBuildGitHashReplaceInfoVersion>True</MSBuildGitHashReplaceInfoVersion>
 </PropertyGroup>
 ```
-### Git describe format
+### Command Output to Assembly Metadata
 
-By default, the package will include the output of the command `git describe --tag --abbrev=0` which will produce the last tag name only.  You can customize the command that is executed by defining the `MSBuildGitDescribeCommand` property in your .csproj file.  For example, if you want the entire tag with the 7 hexadecimal digits representing the abbreviated object name, you can do the following:
+If there are additional commands and output that are needed to be included in the meta data, you can do so by adding them using `AssemblyEmbed`. Examples:
 
 ```xml
-<PropertyGroup>
-  <MSBuildGitDescribeCommand>git describe --tag</MSBuildGitDescribeCommand>
-</PropertyGroup>
+<AssemblyEmbed Include="KeyNameForOutput">
+  <Command>your command</Command>
+  <ValidationRegex>optional regex to validate output</ValidationRegex>
+</AssemblyEmbed>
+```
+
+```xml
+<ItemGroup>
+  <AssemblyEmbed Include="GitDescription">
+    <Command>git describe</Command>
+  </AssemblyEmbed>
+  <AssemblyEmbed Include="GitTag">
+    <Command>git describe --tag --abbrev=0</Command>
+  </AssemblyEmbed>
+</ItemGroup>
 ```
 
 ## Version History

--- a/README.md
+++ b/README.md
@@ -43,15 +43,6 @@ By default, the package will include the output of the command `git describe --t
   <MSBuildGitDescribeCommand>git describe --tag</MSBuildGitDescribeCommand>
 </PropertyGroup>
 ```
-### Assembly version format
-
-By default, this is not overridden. If you would like the `MSBuildGitDescribeCommand` output to override the Assembly Version, then you can do the following:
-
-```xml
-<PropertyGroup>
-  <IncludeMSBuildGitDescribeAssemblyVersion>True</IncludeMSBuildGitDescribeAssemblyVersion>
-</PropertyGroup>
-```
 
 ## Version History
 _1.0.2_


### PR DESCRIPTION
Adding an overridable git describe command setting the standard to just the tag name.

Adding option to add this as the Assembly Version which is off by default.

Updating readme to reflect changes.